### PR TITLE
change dark theme default backgroundColor

### DIFF
--- a/lib/src/style/custom_navigation_bar_theme_data.dart
+++ b/lib/src/style/custom_navigation_bar_theme_data.dart
@@ -15,7 +15,7 @@ class CustomNavigationBarThemeData {
   });
 
   static final CustomNavigationBarThemeData _dark = CustomNavigationBarThemeData(
-    backgroundColor: Colors.black,
+    backgroundColor: const Color.fromARGB(0xFF, 0x1E, 0x1E, 0x1E),
     strokeColor: Colors.white,
     selectedColor: Colors.white,
     unSelectedColor: DefaultCustomNavigationBarStyle.defaultUnselectedColor,


### PR DESCRIPTION
sorry to haste commit the code.
I just found out the dark background color maynot good match material dark theme.
so PR again , only change default dark theme background color

file : /style/custom_navigation_bar_theme_data.dart - line:18

`Colors.black` to `Color.fromARGB(0xFF, 0x1E, 0x1E, 0x1E)`

here is the effect
> Colors.black
> ![Colors.black](https://github.com/rickywen911/custom_bubble_navigation_bar/assets/1745525/dfffd689-a97b-422e-9b10-a48431c58759)

change to 

> Color.fromARGB(0xFF, 0x1E, 0x1E, 0x1E)
> 
![Color.fromARGB(0xFF, 0x1E, 0x1E, 0x1E)](https://github.com/rickywen911/custom_bubble_navigation_bar/assets/1745525/a2c8c5d5-083a-4000-82cb-5dd89f222566)

**in the end**
**pls release new version , so I can use latest code, thanks again , have good day**